### PR TITLE
Rename role to leonidas.nvm in example playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Example Playbook
 
     - hosts: servers
       roles:
-        - role: nvm
+        - role: leonidas.nvm
           nvm:
             user: deploy
             version: v0.4.0


### PR DESCRIPTION
Since most users will use ansible-galaxy to install this role, it's better to set the example to use leonidas.nvm which is the default name created by ansible-galaxy under roles_path.
