### PR TITLE
Added tag nvm-deps to nvm dependencies installation. It is useful on …

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,9 @@
     - curl
     - build-essential
     - libssl-dev
-  tags: nvm
+  tags:
+    - nvm
+    - nvm-deps
 
 - name: Install nvm
   sudo: yes


### PR DESCRIPTION
…systems where you only have access to deployment user, without root profile. By example, jenkins ci localhost environments, unser jenkins user

In cases where python-dev and libssl-dev, by example, were installed by some administrator users, and it is only necessary to isolate nvm unde jenkins user