### PR TITLE
Update to current syntax for failure checks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,5 +38,5 @@
 
 - name: Set default node version to {{ nvm.node_version }}
   command: sudo -iu {{ nvm.user }} nvm alias default {{ nvm.node_version }}
-  when: nvm_check_default|failed
+  when: nvm_check_default.failed
   tags: nvm


### PR DESCRIPTION
Since Ansible doesn't seem to provide the `|failed` filter any more